### PR TITLE
Restore compatibility with Symfony 4.x

### DIFF
--- a/Security/ShibbolethAuthenticator.php
+++ b/Security/ShibbolethAuthenticator.php
@@ -153,7 +153,7 @@ class ShibbolethAuthenticator extends AbstractGuardAuthenticator implements Logo
      *
      * @return RedirectResponse|void
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $providerKey)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
         $this->logger->debug('[ShibbolethAuthenticator::onAuthenticationSuccess]');
 


### PR DESCRIPTION
Remove argument type added to `onAuthenticationSuccess` in f8b3a8aa. Not having a type specified for the argument in the subclass is compatible with both versions, as it is more generic; while having the type is not compatible (has a more restricted signature than the overridden function) with the base class in 4.x causing this error:

```
Niif\ShibAuthBundle\Security\ShibbolethAuthenticator
::onAuthenticationSuccess(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token, string $providerKey)
must be compatible with
Symfony\Component\Security\Guard\GuardAuthenticatorInterface
::onAuthenticationSuccess(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token, $providerKey
```

See symfony/symfony@51b3c2e.